### PR TITLE
set private and public commands and more

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,14 +2,14 @@ import requests
 from bs4 import BeautifulSoup as BS
 from telegram.ext import (
     Updater, 
-    MessageHandler
+    MessageHandler,
+    Filters
 )
 from os import environ
 from sys import argv
 
 
-
-def urbandictionary(sentence: list):
+def urbandictionary(sentence: str) -> str:
     words = sentence.split(" ")
     print(words)
     result = requests.get("https://www.urbandictionary.com/define.php?term=" + '+'.join(words))
@@ -21,23 +21,36 @@ def urbandictionary(sentence: list):
             meaning = soup.findAll("div", {"class": "meaning"})
             return meaning[0].text
         except Exception as e:
-            print(e) # for debugging
+            print(e)  # for debugging
             return "Urban dictionary result: \nNot found!"
 
 
+def meaning_decorator(func: callable) -> callable:
 
+    def wrapper(update, context):
 
-def message_handler(update, context):
-    """Send a message when the command /start is issued."""
-    message_text = update.message.text
-    sentence = message_text[ len('.urban ') :]
-    if message_text.startswith('.urban') and len(message_text.split()) >= 2:
-        meaning = urbandictionary(sentence)
+        """Send a message when the command /start is issued."""
+        message_text: str = update.message.text
+
+        if message_text.startswith('.urban'):
+            message_text: str = message_text.replace('.urban ', '')
+
+        meaning = urbandictionary(message_text)
         update.message.reply_text(meaning)
-        
-        
+
+        return meaning_decorator
+
+    return wrapper
 
 
+@meaning_decorator
+def public(update, context):
+    pass
+
+
+@meaning_decorator
+def private(update, context):
+    pass
 
 
 if __name__ == '__main__':
@@ -49,20 +62,21 @@ if __name__ == '__main__':
             print('Usage: export BOT_TOKEN=<BOT_TOKEN>')
             print('python3 {}'.format(argv[0]))
             exit(1)
-        
+    
 
     """Start the bot."""
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
     # Post version 12 this will no longer be necessary
-    updater = Updater(bot_token, use_context=True)
+    updater = Updater('1328418490:AAGrplpgEZQ19ZhtFPiaIWoOd98khWqiBOw', use_context=True)
 
 
     # Get the dispatcher to register handlers
     dp = updater.dispatcher
 
     # on different commands - answer in Telegram
-    dp.add_handler(MessageHandler(filters=None, callback=message_handler))
+    dp.add_handler(MessageHandler(filters=Filters.regex('^.urban ') & ~Filters.private, callback=public))
+    dp.add_handler(MessageHandler(filters=Filters.private & ~Filters.regex('^.urban '), callback=private))
 
 
     # Start the Bot


### PR DESCRIPTION
I changed the code for a:

1. more elegant code.
2. match PEP8 rules.
3. more comfortable way to contact the bot in private messages.

examle of using bot in **groups**:
    .urban slang

example of using bot in **private**:
    slang

in private - indeed commands.